### PR TITLE
Added prerequisites for bonded roles

### DIFF
--- a/dao/phase-zero.adoc
+++ b/dao/phase-zero.adoc
@@ -550,6 +550,11 @@ To submit a compensation request, create a new issue in the <<compensation-repo>
 
 See https://github.com/bisq-network/compensation/issues/2 for an example compensation request.
 
+https://github.com/bisq-network/roles/blob/master/README.adoc[Prerequisites for bonded roles:] 
+
+ - Complete and up-to-date https://github.com/bisq-network/roles[role specification]
+ - Comments in https://github.com/bisq-network/roles/issues[role’s issue] recapturing the previous month by sharing any relevant data and statistics
+
 Once submitted, your request will be added to the <<voting-spreadsheet>> where stakeholders can <<how-to-vote,vote>> on it.
 
 === submit a proposal


### PR DESCRIPTION
In order to ensure that assignees complete and update their roles specs and comment/share relevant information within their issue