### PR TITLE
Fix broken link to open  bounty issues ( #29 )

### DIFF
--- a/dao/phase-zero.adoc
+++ b/dao/phase-zero.adoc
@@ -461,7 +461,7 @@ The repositories in the https://github.com/bisq-network[bisq-network GitHub orga
 
 === issues labeled '$BSQ bounty' [[bounty-issues]]
 
-https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+org%3Abisq-network+label%3Abounty[issues labeled `$BSQ bounty` in the bisq-network GitHub organization]
+https://github.com/bisq-network/exchange/issues?q=is%3Aissue+is%3Aopen+label%3A%22%24BSQ+bounty%22[issues labeled `$BSQ bounty` in the bisq-network GitHub organization]
 
 === compensation repository [[compensation-repo,bisq-network/compensation repository]]
 


### PR DESCRIPTION
Link
https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+org%3Abisq-network+label%3Abounty
was replaced with good link.